### PR TITLE
v0.2.0: Rust 2024 edition, works on stable (no nightly features)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lsp_doc"
-version = "0.1.0"
-edition = "2021"
-license-file = "LICENSE"
+version = "0.2.0"
+edition = "2024"
+license = "MIT"
 description = "Embed markdown/text files into Rust documentation attributes for LSP hover/preview"
 repository = "https://github.com/MasterTemple/lsp_doc/"
 readme = "README.md"
@@ -12,6 +12,9 @@ keywords = ["lsp", "doc"]
 proc-macro = true
 
 [dependencies]
-syn = "2.0"
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[dev-dependencies]
+lsp_doc = { path = "." }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2024 Blake Scampone
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 | Value 3  | Value 4  |
 ```
 
-
 ### VSCode
 
 ![VSCode Screenshot](vscode.png)
@@ -65,4 +64,10 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 - Paths are relative to the crate root directory
 - Multiple embeds for the same item **are** supported
 - Images **are not** currently supported
-- File contents are cached by rust-analyzer, so if you frequently edit the embedded file, you might not see immediate updates
+- File contents are cached by rust-analyzer (see section below)
+
+## Updating a document
+
+If you frequently edit the embedded file, you will not see immediate updates.
+
+To force an update, you need to save the file or restart the language server (in VSCode: `Ctrl+Shift+P` -> `Rust analyzer: Restart server`)

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,10 @@
+use lsp_doc::lsp_doc;
+
+fn main() {
+    say_hello();
+}
+
+#[lsp_doc("examples/hello.md")]
+pub fn say_hello() {
+    println!("Hello, world!");
+}

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,0 +1,5 @@
+# Hello World
+
+## The quick brown fox jumps over the lazy dog
+
+Once upon a time, in a land far, far away, there lived a fox who was quick and cunning. This fox loved to explore the vast meadows and forests, always on the lookout for adventure. One day, while wandering through the woods, the fox came across a lazy dog lounging in the sun. The dog, with its floppy ears and wagging tail, seemed to be enjoying a peaceful nap. The fox, feeling playful, decided to jump over the dog, showcasing its agility and speed. The dog, startled awake, couldn't help but admire the fox's impressive leap. From that day on, the two became unlikely friends, embarking on many adventures together.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,8 @@
-#![feature(proc_macro_span)]
-
-use std::fs::read_to_string;
-
+use core::panic;
 use proc_macro2::TokenTree;
-use quote::{quote, ToTokens};
-
-fn get_start_index(tree: &TokenTree) -> usize {
-    match tree {
-        TokenTree::Group(group) => group.span(),
-        TokenTree::Ident(ident) => ident.span(),
-        TokenTree::Punct(punct) => punct.span(),
-        TokenTree::Literal(literal) => literal.span(),
-    }
-    .unwrap()
-    .byte_range()
-    .start
-}
+use quote::quote;
+use std::fs::read_to_string;
+use syn::{Attribute, Item};
 
 #[proc_macro_attribute]
 pub fn lsp_doc(
@@ -24,13 +11,6 @@ pub fn lsp_doc(
 ) -> proc_macro::TokenStream {
     let attr: proc_macro2::TokenStream = attr.into();
     let item: proc_macro2::TokenStream = item.into();
-
-    let start_pos = attr
-        .clone()
-        .into_iter()
-        .next()
-        .and_then(|tree| Some(get_start_index(&tree)))
-        .expect("The attribute macro should have a starting position.");
 
     let path = attr
         .clone()
@@ -45,24 +25,36 @@ pub fn lsp_doc(
         })
         .expect("The attribute macro should have a path to the file of type `Literal`.");
 
-    let md = read_to_string(&path).expect(format!("Could not find {path:?}").as_str());
-    let md = format!("\n\n{}\n\n\n", md.trim());
+    let md = read_to_string(&path).unwrap_or_else(|_| {
+        panic!("Could not find {path:?}");
+    });
+    let doc_comment = format!("\n\n{}\n\n\n", md.trim());
+    let doc_attr: Attribute = syn::parse_quote! { #[doc = #doc_comment] };
+    let mut item_ast = syn::parse2::<Item>(item.clone())
+        .expect("The attribute macro should be applied to a valid Rust item.");
 
-    let mut new_items = vec![];
-    let mut inserted = false;
-    for tree in item.into_iter() {
-        let start = get_start_index(&tree);
-        if start > start_pos && inserted == false {
-            new_items.push(quote! {
-                #[doc = #md]
-            });
-            inserted = true;
+    let attrs = match &mut item_ast {
+        Item::Const(c) => &mut c.attrs,
+        Item::Enum(e) => &mut e.attrs,
+        Item::ExternCrate(e) => &mut e.attrs,
+        Item::Fn(f) => &mut f.attrs,
+        Item::ForeignMod(f) => &mut f.attrs,
+        Item::Impl(i) => &mut i.attrs,
+        Item::Macro(m) => &mut m.attrs,
+        Item::Mod(m) => &mut m.attrs,
+        Item::Static(s) => &mut s.attrs,
+        Item::Struct(s) => &mut s.attrs,
+        Item::Trait(t) => &mut t.attrs,
+        Item::TraitAlias(t) => &mut t.attrs,
+        Item::Type(t) => &mut t.attrs,
+        Item::Union(u) => &mut u.attrs,
+        Item::Use(u) => &mut u.attrs,
+        _ => {
+            let error_msg = "lsp_doc can only be used on items that support attributes.";
+            return quote! { compile_error!(#error_msg); #item_ast }.into();
         }
-        new_items.push(tree.to_token_stream());
-    }
+    };
 
-    quote! {
-        #(#new_items)*
-    }
-    .into()
+    attrs.push(doc_attr);
+    quote! { #item_ast }.into()
 }


### PR DESCRIPTION
I tried to use the lib in https://fragmentcolor.org, but it doesn't work with stable toolchain.

I'm writing an update to make it work with stable Rust.

My use case is writing libraries for many platforms at the same time, and I need to replicate documentation in every wrapper/binding. Centralising the docs into a collection of md files will allow to automate the creation of the website as well. Your library fits it perfectly!